### PR TITLE
mvneta support

### DIFF
--- a/LINUX/configure
+++ b/LINUX/configure
@@ -112,7 +112,7 @@ subsys enable null
 subsys enable ptnetmap
 
 # available drivers
-driver_avail="r8169.c virtio_net.c forcedeth.c veth.c \
+driver_avail="r8169.c virtio_net.c forcedeth.c veth.c mvneta.c \
 	e1000 e1000e igb ixgbe ixgbevf i40e vmxnet3 mlx5"
 # enabled drivers (bitfield)
 driver=
@@ -1834,7 +1834,25 @@ EOF
   	}
 EOF
   fi # r8169.c
+
+  # mvneta
+  if drv enabled mvneta.c; then
   
+    add_file_exists_check mvneta.c true "drv_source_error mvneta.c"
+
+    #
+    # Unfortunately the LINUX/configure script cannot handle
+    # a case when the driver has local headers, but is in
+    # a directory with a different name. Work this situation
+    # around by copying mvneta_bm.h directly from sources.
+    #
+    mvneta_bm_path=$(find $src/drivers/ -name "mvneta_bm.h" -print -quit)
+    if [ ! -z "$mvneta_bm_path" ]; then
+      cp $mvneta_bm_path $SRCDIR
+    fi
+
+  fi # mvneta.c
+
   # ixgbe
   if drv enabled ixgbe; then
   

--- a/LINUX/dkms/dkms.conf
+++ b/LINUX/dkms/dkms.conf
@@ -50,3 +50,7 @@ DEST_MODULE_LOCATION[8]=/kernel/drivers/net/ethernet/intel/i40e/
 BUILT_MODULE_NAME[9]=vmxnet3
 BUILT_MODULE_LOCATION[9]=vmxnet3/
 DEST_MODULE_LOCATION[9]=/kernel/drivers/net/vmxnet3/
+
+# mvneta driver
+BUILT_MODULE_NAME[10]=mvneta
+DEST_MODULE_LOCATION[10]=/kernel/drivers/net/ethernet/marvell/

--- a/LINUX/final-patches/vanilla--mvneta.c--41300--41991
+++ b/LINUX/final-patches/vanilla--mvneta.c--41300--41991
@@ -1,0 +1,146 @@
+diff --git a/mvneta.c b/mvneta.c
+index 4313bbb2..89817344 100644
+--- a/mvneta.c
++++ b/mvneta.c
+@@ -448,6 +448,10 @@ struct mvneta_port {
+ 
+ 	u32 indir[MVNETA_RSS_LU_TABLE_SIZE];
+ 
++#if defined(DEV_NETMAP) || defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE)
++	bool netmap_mode;
++#endif /* DEV_NETMAP */
++
+ 	/* Flags for special SoC configurations */
+ 	bool neta_armada3700;
+ 	u16 rx_offset_correction;
+@@ -617,6 +621,11 @@ struct mvneta_rx_queue {
+ 	int first_to_refill;
+ 	u32 refill_num;
+ 
++#if defined(DEV_NETMAP) || defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE)
++	/* Number of descriptors used */
++	int desc_used;
++#endif /* DEV_NETMAP */
++
+ 	/* pointer to uncomplete skb buffer */
+ 	struct sk_buff *skb;
+ 	int left_size;
+@@ -644,6 +653,10 @@ static int global_port_id;
+ #define MVNETA_DRIVER_NAME "mvneta"
+ #define MVNETA_DRIVER_VERSION "1.0"
+ 
++#if defined(DEV_NETMAP) || defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE)
++#include <if_mvneta_netmap.h>
++#endif /* !DEV_NETMAP */
++
+ /* Utility/helper methods */
+ 
+ /* Write helper method */
+@@ -1883,6 +1896,10 @@ static void mvneta_rxq_drop_pkts(struct mvneta_port *pp,
+ 		return;
+ 	}
+ 
++#ifdef DEV_NETMAP
++	if (pp->netmap_mode)
++		return;
++#endif /* DEV_NETMAP */
+ 	for (i = 0; i < rxq->size; i++) {
+ 		struct mvneta_rx_desc *rx_desc = rxq->descs + i;
+ 		void *data = rxq->buf_virt_addr[i];
+@@ -1931,6 +1948,14 @@ static int mvneta_rx_swbm(struct napi_struct *napi,
+ 	u32 rcvd_pkts = 0;
+ 	u32 rcvd_bytes = 0;
+ 
++#ifdef DEV_NETMAP
++	if (pp->netmap_mode) {
++		u_int dummy = 0;
++		int nm_irq = netmap_rx_irq(pp->dev, rxq->id, &dummy);
++		return (nm_irq != NM_IRQ_PASS) ? budget : 1;
++	}
++#endif /* DEV_NETMAP */
++
+ 	/* Get number of received packets */
+ 	rx_todo = mvneta_rxq_busy_desc_num_get(pp, rxq);
+ 	rx_proc = 0;
+@@ -2759,6 +2784,7 @@ static int mvneta_poll(struct napi_struct *napi, int budget)
+ 	int rx_queue;
+ 	struct mvneta_port *pp = netdev_priv(napi->dev);
+ 	struct mvneta_pcpu_port *port = this_cpu_ptr(pp->ports);
++	int bit;
+ 
+ 	if (!netif_running(pp->dev)) {
+ 		napi_complete(napi);
+@@ -2779,6 +2805,13 @@ static int mvneta_poll(struct napi_struct *napi, int budget)
+ 
+ 	/* Release Tx descriptors */
+ 	if (cause_rx_tx & MVNETA_TX_INTR_MASK_ALL) {
++#ifdef DEV_NETMAP
++		if (pp->netmap_mode) {
++			for_each_set_bit(bit, (long unsigned int *)&cause_rx_tx, 8) {
++				netmap_tx_irq(pp->dev, bit);
++			}
++		}
++#endif /* DEV_NETMAP */
+ 		mvneta_tx_done_gbe(pp, (cause_rx_tx & MVNETA_TX_INTR_MASK_ALL));
+ 		cause_rx_tx &= ~MVNETA_TX_INTR_MASK_ALL;
+ 	}
+@@ -2833,6 +2866,12 @@ static int mvneta_rxq_fill(struct mvneta_port *pp, struct mvneta_rx_queue *rxq,
+ {
+ 	int i;
+ 
++#ifdef DEV_NETMAP
++	if (pp->netmap_mode) {
++		mvneta_netmap_rxq_init_buffers(pp, rxq, num);
++		return num;
++	}
++#endif /* DEV_NETMAP */
+ 	for (i = 0; i < num; i++) {
+ 		memset(rxq->descs + i, 0, sizeof(struct mvneta_rx_desc));
+ 		if (mvneta_rx_refill(pp, rxq->descs + i, rxq,
+@@ -3143,7 +3182,10 @@ static int mvneta_setup_txqs(struct mvneta_port *pp)
+ 			return err;
+ 		}
+ 	}
+-
++#ifdef DEV_NETMAP
++	if (pp->netmap_mode)
++		mvneta_netmap_txq_init_buffers(pp);
++#endif /* DEV_NETMAP */
+ 	return 0;
+ }
+ 
+@@ -3235,6 +3277,13 @@ static int mvneta_change_mtu(struct net_device *dev, int mtu)
+ 	struct mvneta_port *pp = netdev_priv(dev);
+ 	int ret;
+ 
++#ifdef DEV_NETMAP
++	if (pp->netmap_mode) {
++		netdev_err(dev, "MTU can not be modified for port configured to Netmap mode\n");
++		return -EPERM;
++	}
++#endif /* DEV_NETMAP */
++
+ 	if (!IS_ALIGNED(MVNETA_RX_PKT_SIZE(mtu), 8)) {
+ 		netdev_info(dev, "Illegal MTU value %d, rounding to %d\n",
+ 			    mtu, ALIGN(MVNETA_RX_PKT_SIZE(mtu), 8));
+@@ -4619,6 +4668,10 @@ static int mvneta_probe(struct platform_device *pdev)
+ 
+ 	platform_set_drvdata(pdev, pp->dev);
+ 
++#ifdef DEV_NETMAP
++	mvneta_netmap_attach(pp);
++#endif /* DEV_NETMAP */
++
+ 	return 0;
+ 
+ err_netdev:
+@@ -4651,6 +4704,9 @@ static int mvneta_remove(struct platform_device *pdev)
+ 	struct mvneta_port *pp = netdev_priv(dev);
+ 
+ 	unregister_netdev(dev);
++#ifdef DEV_NETMAP
++	netmap_detach(dev);
++#endif /* DEV_NETMAP */
+ 	clk_disable_unprepare(pp->clk_bus);
+ 	clk_disable_unprepare(pp->clk);
+ 	free_percpu(pp->ports);

--- a/LINUX/if_mvneta_netmap.h
+++ b/LINUX/if_mvneta_netmap.h
@@ -1,0 +1,386 @@
+/*
+ * Copyright (C) 2020 Semihalf
+ * Author: Marek Maslanka <marek.maslanka@semihalf.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+
+#include <bsd_glue.h>
+#include <net/netmap.h>
+#include <netmap/netmap_kern.h>
+
+#define SOFTC_T	mvneta_port
+
+#define mvneta_driver_name netmap_mvneta_driver_name
+char mvneta_driver_name[] = "mvneta" NETMAP_LINUX_DRIVER_SUFFIX;
+
+#define MVNETA_TX_PKT_OFFSET_MASK(offset) (((offset) << 23) & 0x3F800000)
+
+static int mvneta_stop(struct net_device *dev);
+static int mvneta_open(struct net_device *dev);
+static void mvneta_rx_desc_fill(struct mvneta_rx_desc *rx_desc,
+				u32 phys_addr, void *virt_addr,
+				struct mvneta_rx_queue *rxq);
+static int mvneta_rxq_busy_desc_num_get(struct mvneta_port *pp,
+					struct mvneta_rx_queue *rxq);
+static struct mvneta_rx_desc *
+mvneta_rxq_next_desc_get(struct mvneta_rx_queue *rxq);
+static struct mvneta_tx_desc *
+mvneta_txq_next_desc_get(struct mvneta_tx_queue *txq);
+static void mvneta_rxq_desc_num_update(struct mvneta_port *pp,
+				       struct mvneta_rx_queue *rxq,
+				       int rx_done, int rx_filled);
+static void mvneta_rxq_non_occup_desc_add(struct mvneta_port *pp,
+					  struct mvneta_rx_queue *rxq,
+					  int ndescs);
+static void mvneta_txq_inc_put(struct mvneta_tx_queue *txq);
+static void mvneta_txq_pend_desc_add(struct mvneta_port *pp,
+				     struct mvneta_tx_queue *txq,
+				     int pend_desc);
+static int mvneta_txq_sent_desc_proc(struct mvneta_port *pp,
+				     struct mvneta_tx_queue *txq);
+static void mvneta_rx_error(struct mvneta_port *pp,
+			    struct mvneta_rx_desc *rx_desc);
+
+static int mvneta_netmap_reg(struct netmap_adapter *na, int onoff)
+{
+	struct mvneta_port *pp = (struct mvneta_port *)netdev_priv(na->ifp);
+	int error = 0;
+
+	if (na == NULL)
+		return -EINVAL;
+
+	if (!netif_running(na->ifp))
+		return -EINVAL;
+
+	mvneta_stop(pp->dev);
+
+	pp->netmap_mode = onoff;
+	if (onoff) /* enable netmap mode */
+		nm_set_native_flags(na);
+	else
+		nm_clear_native_flags(na);
+
+	if (netif_running(pp->dev)) {
+		mvneta_open(pp->dev);
+		pr_debug("%s: starting interface\n", na->ifp->name);
+	}
+	return error;
+}
+
+static int mvneta_netmap_rxsync(struct netmap_kring *kring, int flags)
+{
+	struct netmap_adapter *na = kring->na;
+	struct ifnet *ifp = na->ifp;
+	struct netmap_ring *ring = kring->ring;
+	u_int ring_nr = kring->ring_id;
+	u_int nm_i;	/* index into the netmap ring */
+	u_int nic_i;	/* index into the NIC ring */
+	u_int n;
+	int cpu;
+	u_int const lim = kring->nkr_num_slots - 1;
+	u_int const head = kring->rhead;
+	int force_update = (flags & NAF_FORCE_READ) || kring->nr_kflags & NKR_PENDINTR;
+
+	/* device-specific */
+	struct SOFTC_T *adapter = netdev_priv(ifp);
+	struct mvneta_rx_queue *rxr = &adapter->rxqs[ring_nr];
+
+	if (!netif_carrier_ok(ifp))
+		return 0;
+
+	if (head > lim)
+		return netmap_ring_reinit(kring);
+
+	cpu = get_cpu();
+
+	rmb();
+
+	/*
+	 * First part: import newly received packets.
+	 */
+	if (netmap_no_pendintr || force_update) {
+		int rx_todo;
+
+		nic_i = rxr->next_desc_to_proc;
+		nm_i = netmap_idx_n2k(kring, nic_i); /* map NIC ring index to netmap ring index */
+
+		rx_todo = mvneta_rxq_busy_desc_num_get(adapter, rxr);
+		rx_todo = (rx_todo >= lim - rxr->desc_used) ? lim - rxr->desc_used - 1 : rx_todo;
+		for (n = 0; n < rx_todo; n++) {
+			struct mvneta_rx_desc *curr = mvneta_rxq_next_desc_get(rxr);
+			struct netmap_slot *slot = &ring->slot[nm_i];
+			uint64_t paddr;
+			uint32_t rx_status = curr->status;
+
+			if (rx_status & MVNETA_RXD_ERR_SUMMARY) {
+				mvneta_rx_error(adapter, curr);
+			} else {
+				PNMB_O(kring, slot, &paddr);
+				slot->len = curr->data_size;
+				netmap_sync_map_cpu(na, (bus_dma_tag_t) na->pdev, &paddr,
+						    slot->len, NR_RX);
+				if (rx_status & MVNETA_RXD_FIRST_DESC) {
+					slot->len -= MVNETA_MH_SIZE + ETH_FCS_LEN;
+					slot->data_offs = MVNETA_MH_SIZE;
+				}
+			}
+			slot->flags = 0;
+			nm_i = nm_next(nm_i, lim);
+			nic_i = nm_next(nic_i, lim);
+		}
+		if (n) { /* update the state variables */
+			kring->nr_hwtail = nm_i;
+			rxr->next_desc_to_proc = nic_i;
+			rxr->desc_used += n;
+			mvneta_rxq_desc_num_update(adapter, rxr, n, 0);
+		}
+		kring->nr_kflags &= ~NKR_PENDINTR;
+	}
+
+	/*
+	 * Second part: skip past packets that userspace has released.
+	 */
+	nm_i = kring->nr_hwcur;
+	if (nm_i != head) {
+		nic_i = netmap_idx_k2n(kring, nm_i);
+		for (n = 0; nm_i != head; n++) {
+			struct netmap_slot *slot = &ring->slot[nm_i];
+			uint64_t paddr;
+			void *addr = PNMB(na, slot, &paddr);
+
+			if (addr == NETMAP_BUF_BASE(na)) /* bad buf */
+				goto ring_reset;
+
+			if (slot->flags & NS_BUF_CHANGED) {
+				struct mvneta_rx_desc *rx_desc;
+				rx_desc = (struct mvneta_rx_desc *)rxr->descs + nic_i;
+				mvneta_rx_desc_fill(rx_desc, paddr, addr, rxr);
+				slot->flags &= ~NS_BUF_CHANGED;
+			} else {
+				netmap_sync_map_dev(na, (bus_dma_tag_t) na->pdev, &paddr,
+						    NETMAP_BUF_SIZE(na), NR_RX);
+			}
+			slot->len = 0;
+			nm_i = nm_next(nm_i, lim);
+			nic_i = nm_next(nic_i, lim);
+		}
+		kring->nr_hwcur = head;
+		wmb();
+		mvneta_rxq_non_occup_desc_add(adapter, rxr, n);
+		rxr->desc_used -= n;
+	}
+
+	put_cpu();
+	return 0;
+
+ring_reset:
+	put_cpu();
+	return netmap_ring_reinit(kring);
+}
+
+static int mvneta_netmap_txsync(struct netmap_kring *kring, int flags)
+{
+	struct netmap_adapter *na = kring->na;
+	struct ifnet *ifp = na->ifp;
+	struct netmap_ring *ring = kring->ring;
+	u_int ring_nr = kring->ring_id;
+	u_int nm_i;	/* index into the netmap ring */
+	u_int nic_i;	/* index into the NIC ring */
+	u_int n;
+	u_int const lim = kring->nkr_num_slots - 1;
+	u_int const head = kring->rhead;
+
+	/* device-specific */
+	struct SOFTC_T *adapter = netdev_priv(ifp);
+	struct mvneta_tx_queue *txr = &adapter->txqs[ring_nr];
+	struct mvneta_tx_desc *curr;
+
+	rmb();
+	/*
+	 * First part: process new packets to send.
+	 */
+
+	if (!netif_carrier_ok(ifp)) {
+		return 0;
+	}
+
+	nm_i = kring->nr_hwcur;
+	if (nm_i != head) {	/* we have new packets to send */
+		nic_i = netmap_idx_k2n(kring, nm_i);
+		for (n = 0; nm_i != head; n++) {
+			struct netmap_slot *slot = &ring->slot[nm_i];
+			u_int len = slot->len;
+			uint64_t paddr;
+			uint64_t offset = nm_get_offset(kring, slot);
+			void *addr = PNMB(na, slot, &paddr);
+			/* Get a descriptor for the first part of the packet */
+			curr = mvneta_txq_next_desc_get(txr);
+
+			NM_CHECK_ADDR_LEN(na, addr, len);
+			NM_CHECK_ADDR_LEN_OFF(na, len, offset);
+
+			if (slot->flags & NS_BUF_CHANGED) {
+				curr->buf_phys_addr = paddr;
+			}
+			curr->data_size = len;
+			curr->command = MVNETA_TX_L4_CSUM_NOT | MVNETA_TXD_FLZ_DESC |
+					MVNETA_TX_PKT_OFFSET_MASK(offset + slot->data_offs);
+
+			slot->flags &= ~(NS_REPORT | NS_BUF_CHANGED | NS_MOREFRAG);
+
+			netmap_sync_map_dev(na, (bus_dma_tag_t) na->pdev, &paddr, len, NR_TX);
+			mvneta_txq_inc_put(txr);
+
+			nm_i = nm_next(nm_i, lim);
+			nic_i = nm_next(nic_i, lim);
+		}
+		mvneta_txq_pend_desc_add(adapter, txr, n);
+		kring->nr_hwcur = head;
+
+		wmb();	/* synchronize writes to the NIC ring */
+	}
+
+	nm_i = kring->nr_hwtail;
+	n = mvneta_txq_sent_desc_proc(adapter, txr);
+	/* sync all buffers that we are returning to userspace */
+	while (n) {
+		struct netmap_slot *slot = &ring->slot[nm_i];
+		uint64_t paddr;
+		(void)PNMB_O(kring, slot, &paddr);
+
+		netmap_sync_map_cpu(na, (bus_dma_tag_t) na->pdev,
+				    &paddr, slot->len, NR_TX);
+		slot->len = 0;
+		slot->data_offs = 0;
+		nm_i = nm_next(nm_i, lim);
+		n--;
+	}
+	kring->nr_hwtail = nm_i;
+
+	return 0;
+}
+
+/*
+ * Make the rx ring point to the netmap buffers.
+ */
+static int mvneta_netmap_rxq_init_buffers(struct SOFTC_T *adapter,
+					  struct mvneta_rx_queue *rxr,
+					  int num)
+{
+	struct ifnet *ifp = adapter->dev;
+	struct netmap_adapter *na = NA(ifp);
+	struct netmap_slot *slot;
+	struct mvneta_rx_desc *rx_desc;
+	struct netmap_kring *kring;
+
+	int i, si;
+	uint64_t paddr;
+	void *vaddr;
+
+	if (!nm_native_on(na)) {
+		nm_prinf("Interface not in native netmap mode");
+		return 0;	/* nothing to reinitialize */
+	}
+
+	kring = na->rx_rings[rxr->id];
+	mvneta_rxq_non_occup_desc_add(adapter, rxr, num);
+
+	/* initialize the rx ring */
+	slot = netmap_reset(na, NR_RX, rxr->id, 0);
+	if (!slot) {
+		nm_prerr("Error: RX slot is null");
+		return 0;
+	}
+
+	for (i = 0; i < num; i++) {
+		si = netmap_idx_n2k(na->rx_rings[rxr->id], i);
+		vaddr = PNMB_O(kring, slot + si, &paddr);
+		rx_desc = (struct mvneta_rx_desc *)rxr->descs + i;
+		mvneta_rx_desc_fill(rx_desc, paddr, vaddr, rxr);
+	}
+	rxr->next_desc_to_proc = 0;
+	rxr->desc_used = 0;
+	/* Force memory writes to complete */
+	wmb();
+	return 1;
+}
+
+/*
+ * Make the tx ring point to the netmap buffers.
+ */
+static int mvneta_netmap_txq_init_buffers(struct SOFTC_T *adapter)
+{
+	struct ifnet *ifp = adapter->dev;
+	struct netmap_adapter* na = NA(ifp);
+	struct netmap_slot* slot;
+	struct mvneta_tx_desc *tx_desc;
+	struct mvneta_tx_queue *txr;
+	int i, t, si;
+	uint64_t paddr;
+
+	if (!nm_native_on(na))
+		return 0;
+
+	for (t = 0; t < na->num_tx_rings; t++) {
+		txr = &adapter->txqs[t];
+		slot = netmap_reset(na, NR_TX, t, 0);
+		if (!slot) {
+			nm_prinf("Skipping TX ring %d", t);
+			continue;
+		}
+		/* initialize the tx ring for netmap mode */
+		for (i = 0; i < na->num_tx_desc; i++) {
+			si = netmap_idx_n2k(na->tx_rings[t], i);
+			PNMB(na, slot + si, &paddr);
+			tx_desc = (struct mvneta_tx_desc *)txr->descs + i;
+			tx_desc->buf_phys_addr = paddr;
+		}
+	}
+	return 0;
+}
+
+static void mvneta_netmap_attach(struct SOFTC_T *adapter)
+{
+	struct netmap_adapter na;
+
+	bzero(&na, sizeof(na));
+
+	na.ifp = adapter->dev;
+	na.pdev = adapter->dev->dev.parent;
+	na.na_flags = NAF_OFFSETS;
+	na.num_tx_desc = adapter->tx_ring_size;
+	na.num_rx_desc = adapter->rx_ring_size;
+	na.nm_txsync = mvneta_netmap_txsync;
+	na.nm_rxsync = mvneta_netmap_rxsync;
+	na.nm_register = mvneta_netmap_reg;
+	na.num_tx_rings = txq_number;
+	na.num_rx_rings = rxq_number;
+	na.rx_buf_maxsize = 1500;
+
+	adapter->netmap_mode = false;
+
+	netmap_attach(&na);
+}
+
+/* end of file */

--- a/LINUX/openwrt/netmap/Makefile
+++ b/LINUX/openwrt/netmap/Makefile
@@ -37,6 +37,14 @@ define KernelPackage/r8169-netmap
   FILES=$(wildcard $(PKG_BUILD_DIR)/LINUX/r8169-netmap.ko)
 endef
 
+define KernelPackage/mvneta-netmap
+  TITLE:=Netmap enabled mvneta driver
+  SECTION:=kernel
+  SUBMENU:=Other modules
+  DEPENDS:= +kmod-netmap
+  FILES=$(wildcard $(PKG_BUILD_DIR)/LINUX/mvneta-netmap.ko)
+endef
+
 define KernelPackage/e1000-netmap
   TITLE:=Netmap enabled e1000 driver
   SECTION:=kernel

--- a/apps/bridge/bridge.c
+++ b/apps/bridge/bridge.c
@@ -94,6 +94,7 @@ process_rings(struct netmap_ring *rxring, struct netmap_ring *txring,
 		if (zerocopy) {
 			uint32_t pkt = ts->buf_idx;
 			ts->buf_idx = rs->buf_idx;
+			ts->data_offs = rs->data_offs;
 			rs->buf_idx = pkt;
 			/* report the buffer change. */
 			ts->flags |= NS_BUF_CHANGED;
@@ -101,8 +102,8 @@ process_rings(struct netmap_ring *rxring, struct netmap_ring *txring,
 			/* copy the NS_MOREFRAG */
 			rs->flags = (rs->flags & ~NS_MOREFRAG) | (ts->flags & NS_MOREFRAG);
 		} else {
-			char *rxbuf = NETMAP_BUF(rxring, rs->buf_idx);
-			char *txbuf = NETMAP_BUF(txring, ts->buf_idx);
+			char *rxbuf = NETMAP_BUF(rxring, rs->buf_idx) + rs->data_offs;
+			char *txbuf = NETMAP_BUF(txring, ts->buf_idx) + rs->data_offs;
 			nm_pkt_copy(rxbuf, txbuf, ts->len);
 		}
 		j = nm_ring_next(rxring, j);

--- a/ci/build-linux
+++ b/ci/build-linux
@@ -87,7 +87,7 @@ popd
 
 # First build in-tree-only drivers
 echo "Building vanilla-only drivers"
-./configure --no-ext-drivers --driver-suffix=_netmap --kernel-dir=$PWD/linux-${KERNEL_VERSION} --drivers=r8169.c,virtio_net.c,forcedeth.c,veth.c,e1000,vmxnet3 --enable-ptnetmap
+./configure --no-ext-drivers --driver-suffix=_netmap --kernel-dir=$PWD/linux-${KERNEL_VERSION} --drivers=r8169.c,virtio_net.c,forcedeth.c,veth.c,mvneta.c,e1000,vmxnet3 --enable-ptnetmap
 make -j $PROC_COUNT
 
 # Then build external intel drivers

--- a/share/man/man4/netmap.4
+++ b/share/man/man4/netmap.4
@@ -834,7 +834,7 @@ On
 .Xr re 4 ,
 .Xr vtnet 4 .
 .Pp
-On Linux e1000, e1000e, i40e, igb, ixgbe, ixgbevf, r8169, virtio_net, vmxnet3.
+On Linux e1000, e1000e, i40e, igb, ixgbe, ixgbevf, mvneta, r8169, virtio_net, vmxnet3.
 .Pp
 NICs without native support can still be used in
 .Nm

--- a/sys/net/netmap.h
+++ b/sys/net/netmap.h
@@ -163,6 +163,7 @@
 struct netmap_slot {
 	uint32_t buf_idx;	/* buffer index */
 	uint16_t len;		/* length for this slot */
+	uint16_t data_offs;	/* offset to data start point in the buffer */
 	uint16_t flags;		/* buf changed, etc. */
 	uint64_t ptr;		/* pointer for indirect buffers */
 };


### PR DESCRIPTION
The netmap mvneta driver support with a patch that enables build and operation with the v4.19.91 Linux kernel. The driver was examined and stressed during a number of tests (including overnight runs) - a description can be found in Test cases chapter.
The measured performance is following:
• RX: 1.488 Mpps (linerate of 64B packets) with pkt-gen application
• TX: 1.488 Mpps (linerate of 64B packets) with pkt-gen application
• Forwarding - unidirectional: 1.488 Mpps (linerate of 64B packets) with bridge application
• Forwarding - bidirectional: 1.665 Mpps with bridge application, which should be understood as an actual limit of the
device under test.