### PR TITLE
DSA support in netmap

### DIFF
--- a/LINUX/Kbuild.in
+++ b/LINUX/Kbuild.in
@@ -15,6 +15,7 @@ remoteobjs-$(CONFIG_NETMAP_PIPE)    += netmap_pipe.o
 remoteobjs-$(CONFIG_NETMAP_MONITOR) += netmap_monitor.o
 remoteobjs-$(CONFIG_NETMAP_GENERIC) += netmap_generic.o
 remoteobjs-$(CONFIG_NETMAP_NULL)    += netmap_null.o
+remoteobjs-$(CONFIG_NETMAP_DSA)     += netmap_dsa.o
 
 define remote_template
 $$(obj)/$(1): %.o: $$(SRCDIR)/../sys/dev/netmap/$(2) FORCE

--- a/LINUX/README.md
+++ b/LINUX/README.md
@@ -73,6 +73,40 @@ used to access NICs without native netmap support (at reduced performance).
 driver).
 * **sink**: a dummy drop-everything device with native netmap support.
 It can emulate a link with configurable packet rate.
+* **dsa**: support for Distributed Switch Architecture (DSA).
+
+### DSA subsystem
+
+Distributed Switch Architecture (DSA) is a subsystem supported by Linux kernel
+and it's description can be found in https://www.kernel.org/doc/Documentation/networking/dsa/dsa.txt.
+
+DSA ports configuration is provided to netmap application in a dsa.txt configuration file.
+Below is an example of dsa.txt configurtion file:
+
+```
+#Tag type: edsa or dsa
+tag-type edsa
+
+#Profile name   Slave port name   Slave port number   Bind mode   Cpu port name  Vlan id  Vlan prio
+wan_net                wan		1		  hw	      eth1
+wan_net_vlan           wan              1                 hw          eth1         1073       7
+wan_host               wan              1                 host        eth1
+
+lan0_net               lan0		2		  hw	      eth1
+lan0_net_vlan          lan0             2                 hw          eth1         4036       1
+lan0_host              lan0             2                 host        eth1
+
+lan1_net	       lan1		3		  hw	      eth1
+lan1_net_vlan          lan1             3                 hw          eth1         3500       4
+lan1_host              lan1             3                 host        eth1
+```
+
+In case of DSA subsystem profile name is passed to a netmap application instead of interface name because
+configuration file can include multiple configurations for a selected interface name as in the above
+example. Slave port name and number are DSA slave port and its number and can be found in a device tree.
+Bind mode determines whether interface will bind to host rings (host), network rings (hw) or both (all).
+Cpu port is a DSA cpu port name and currently only single cpu port is supported. Vlan identifier and vlan
+priority are optionall and when confiugred will be applied to egress traffic on selected interface.
 
 ### NIC drivers
 

--- a/LINUX/configure
+++ b/LINUX/configure
@@ -95,7 +95,7 @@ setop()
 
 # available subsystems
 subsystem_avail="vale pipe monitor generic ptnetmap sink \
-	extmem null"
+	extmem null dsa"
 #enabled subsystems (bitfield)
 subsystem=0
 
@@ -322,6 +322,8 @@ Available options:
   --disable-generic   	       disable the generic netmap adapter
   --enable-ptnetmap            enable ptnetmap
   --disable-ptnetmap           disable ptnetmap
+  --enable-dsa                 enable dsa
+  --disable-dsa                disable dsa
   --enable-sink   	       enable the netmap sink device
   --disable-sink   	       disable the netmap sink device
   --enable-extmem   	       enable the external memory allocators

--- a/LINUX/netmap.mak.in
+++ b/LINUX/netmap.mak.in
@@ -118,7 +118,7 @@ clean-apps: $(APPS_LIST:%=clean-app-%)
 .PHONY: apps $(APPS_BUILD) install-apps $(APPS_INSTALL)
 define apps_actions
 build-app-$(1): libnetmap
-	+$(MAKE) -C build-apps/$(1) SRCDIR=$(SRCDIR)/.. BUILDDIR=$(BUILDDIR) CC="$(APPS_CC)" LD="$(APPS_LD)"
+	+$(MAKE) -C build-apps/$(1) SRCDIR=$(SRCDIR)/.. BUILDDIR=$(BUILDDIR) CC="$(APPS_CC)" LD="$(APPS_LD)" SUBSYS_FLAGS="$(SUBSYS_FLAGS)"
 
 install-app-$(1):
 	$(MAKE) -C build-apps/$(1) install SRCDIR=$(SRCDIR)/.. BUILDDIR=$(BUILDDIR) DESTDIR="$(abspath $(DESTDIR))" PREFIX="$(PREFIX)"
@@ -132,7 +132,7 @@ $(foreach a,$(APPS_LIST),$(eval $(call apps_actions,$(a))))
 	@echo '$($*)'
 
 libnetmap:
-	+$(MAKE) -C build-libnetmap SRCDIR=$(SRCDIR)/.. BUILDDIR=$(BUILDDIR) CC="$(APPS_CC)" LD="$(APPS_LD)"
+	+$(MAKE) -C build-libnetmap SRCDIR=$(SRCDIR)/.. BUILDDIR=$(BUILDDIR) CC="$(APPS_CC)" LD="$(APPS_LD)" SUBSYS_FLAGS="$(SUBSYS_FLAGS)"
 
 clean-libnetmap:
 	+$(MAKE) -C build-libnetmap clean SRCDIR=$(SRCDIR)/.. BUILDDIR=$(BUILDDIR)

--- a/LINUX/netmap_linux.c
+++ b/LINUX/netmap_linux.c
@@ -1222,7 +1222,7 @@ linux_netmap_poll(struct file *file, struct poll_table_struct *pwait)
 		.pwait = pwait
 	};
 	struct netmap_priv_d *priv = file->private_data;
-	return netmap_poll(priv, events, &sr);
+	return priv->np_na->nm_poll(priv, events, &sr);
 }
 
 #ifdef NETMAP_LINUX_HAVE_VMFAULT_T

--- a/apps/bridge/GNUmakefile
+++ b/apps/bridge/GNUmakefile
@@ -13,6 +13,7 @@ CFLAGS = -O2 -pipe
 CFLAGS += -Werror -Wall -Wunused-function
 CFLAGS += -I $(SRCDIR)/sys -I $(SRCDIR)/apps/include -I$(SRCDIR)/libnetmap
 CFLAGS += -Wextra
+CFLAGS += $(SUBSYS_FLAGS)
 
 LDFLAGS += -L $(BUILDDIR)/build-libnetmap
 LDLIBS += -lnetmap

--- a/apps/dedup/GNUmakefile
+++ b/apps/dedup/GNUmakefile
@@ -13,6 +13,7 @@ CFLAGS = -O2 -pipe -g
 CFLAGS += -Werror -Wall -Wunused-function
 CFLAGS += -I $(SRCDIR)/sys -I $(SRCDIR)/apps/include
 CFLAGS += -Wextra
+CFLAGS += $(SUBSYS_FLAGS)
 #CFLAGS += -DDEDUP_HASH_STAT
 
 LDLIBS += -lpthread

--- a/apps/lb/GNUmakefile
+++ b/apps/lb/GNUmakefile
@@ -13,6 +13,7 @@ CFLAGS = -O2 -pipe
 CFLAGS += -Werror -Wall -Wunused-function
 CFLAGS += -I $(SRCDIR)/sys -I $(SRCDIR)/apps/include -I $(SRCDIR)/libnetmap
 CFLAGS += -Wextra
+CFLAGS += $(SUBSYS_FLAGS)
 
 LDFLAGS += -L $(BUILDDIR)/build-libnetmap
 LDLIBS += -lnetmap -lpthread -lm

--- a/apps/nmreplay/GNUmakefile
+++ b/apps/nmreplay/GNUmakefile
@@ -13,6 +13,7 @@ CFLAGS = -O2 # -pipe -g
 CFLAGS += -Werror -Wall -Wunused-function
 CFLAGS += -I $(SRCDIR)/sys -I $(SRCDIR)/apps/include -I $(SRCDIR)/libnetmap
 CFLAGS += -Wextra
+CFLAGS += $(SUBSYS_FLAGS)
 
 LDFLAGS += -L $(BUILDDIR)/build-libnetmap
 LDLIBS += -lnetmap -lpthread

--- a/apps/pkt-gen/GNUmakefile
+++ b/apps/pkt-gen/GNUmakefile
@@ -13,6 +13,7 @@ CFLAGS = -O2 -pipe
 CFLAGS += -Werror -Wall -Wunused-function
 CFLAGS += -I $(SRCDIR)/sys -I $(SRCDIR)/apps/include -I $(SRCDIR)/libnetmap
 CFLAGS += -Wextra -Wno-address-of-packed-member
+CFLAGS += $(SUBSYS_FLAGS)
 
 LDFLAGS = -L $(BUILDDIR)/build-libnetmap
 LDLIBS += -lpthread -lm -lnetmap

--- a/apps/tlem/GNUmakefile
+++ b/apps/tlem/GNUmakefile
@@ -13,6 +13,7 @@ CFLAGS = -O2 -pipe -g
 CFLAGS += -Werror -Wall -Wunused-function -Wno-address-of-packed-member
 CFLAGS += -I $(SRCDIR)/sys -I $(SRCDIR)/apps/include -I$(SRCDIR)/libnetmap
 CFLAGS += -Wextra
+CFLAGS += $(SUBSYS_FLAGS)
 
 LDFLAGS += -L $(BUILDDIR)/build-libnetmap
 LDLIBS += -lnetmap -lpthread

--- a/apps/vale-ctl/GNUmakefile
+++ b/apps/vale-ctl/GNUmakefile
@@ -13,6 +13,7 @@ CFLAGS = -O2 -pipe
 CFLAGS += -Werror -Wall -Wunused-function
 CFLAGS += -I $(SRCDIR)/sys -I $(SRCDIR)/apps/include -I $(SRCDIR)/libnetmap
 CFLAGS += -Wextra
+CFLAGS += $(SUBSYS_FLAGS)
 
 LDFLAGS += -L $(BUILDDIR)/build-libnetmap
 LDLIBS = -lnetmap

--- a/libnetmap/GNUmakefile
+++ b/libnetmap/GNUmakefile
@@ -3,6 +3,7 @@ PREFIX ?= usr/local
 CFLAGS=-O2 -pipe -Wall -Werror
 CFLAGS +=-g
 CFLAGS += -I $(SRCDIR)/sys
+CFLAGS += $(SUBSYS_FLAGS)
 VPATH = $(SRCDIR)/libnetmap
 SRCS=$(notdir $(wildcard $(SRCDIR)/libnetmap/*.c))
 OBJS=$(SRCS:.c=.o)

--- a/libnetmap/libnetmap.h
+++ b/libnetmap/libnetmap.h
@@ -489,6 +489,7 @@ void nmreq_header_init(struct nmreq_header *hdr, uint16_t reqtype, void *body);
 
 /* nmreq_header_decode - initialize an nmreq_header
  * @ppspec:	(in/out) pointer to a pointer to the portspec
+ * @subsys_type:(out) pointer to the subsystem type
  * @hdr:	pointer to the nmreq_header to be initialized
  * @ctx:	pointer to the nmctx to use (for errors)
  *
@@ -500,10 +501,11 @@ void nmreq_header_init(struct nmreq_header *hdr, uint16_t reqtype, void *body);
  * EINVAL, @pifname is unchanged, *@hdr is also unchanged, and an error message
  * is sent through @ctx->error().
  */
-int nmreq_header_decode(const char **ppspec, struct nmreq_header *hdr,
-		struct nmctx *ctx);
+int nmreq_header_decode(const char **ppspec, uint16_t *subsys_type,
+		struct nmreq_header *hdr, struct nmctx *ctx);
 
-/* nmreq_regiter_decode - initialize an nmreq_register
+/* nmreq_register_decode - initialize an nmreq_register for netmap and vale
+ * 			  subsystems
  * @pmode:	(in/out) pointer to a pointer to an opening mode
  * @reg:	pointer to the nmreq_register to be initialized
  * @ctx:	pointer to the nmctx to use (for errors)
@@ -523,6 +525,24 @@ int nmreq_header_decode(const char **ppspec, struct nmreq_header *hdr,
  * is sent through @ctx->error().
  */
 int nmreq_register_decode(const char **pmode, struct nmreq_register *reg,
+		struct nmctx *ctx);
+
+/* nmreq_register_decode_dsa - initialize an nmreq_register for dsa subsystem
+ *
+ * @pmode:	(in/out) pointer to a pointer to an opening mode
+ * @reg:	pointer to the nmreq_register to be initialized
+ * @ctx:	pointer to the nmctx to use (for errors)
+ *
+ * This function fills the nr_mode, cpu_pirt_name, port_num, and tag_type
+ * fields of the structure pointed by @reg, according to the opening mode
+ * specified by *@pmode. The other fields of *@reg are unchanged.  The @pmode
+ * is updated to point at the first char past the opening mode.
+ *
+ * Returns 0 on success.  In case of error, -1 is returned with errno set to
+ * EINVAL, @pmode is unchanged, *@reg is also unchanged, and an error message
+ * is sent through @ctx->error().
+ */
+int nmreq_register_decode_dsa(const char **pmode, struct nmreq_register *reg,
 		struct nmctx *ctx);
 
 /* nmreq_options_decode - parse the "options" part of the portspec

--- a/libnetmap/libnetmap.h
+++ b/libnetmap/libnetmap.h
@@ -735,9 +735,12 @@ void nmctx_unlock(struct nmctx *);
 
 #ifdef CONFIG_NETMAP_DSA
 
+#define DSA_IF_PREFIX "dsa:"
 int nmdsa_init(void);
+void nmdsa_fini(void);
 void nmdsa_config_print(void);
-
+int nmdsa_find_port_cfg(struct nmport_d *d, const char *iface,
+		char *dsa_iface_buf, uint16_t buf_len);
 #else
 
 static inline int nmdsa_init(void)
@@ -748,6 +751,7 @@ static inline int nmdsa_init(void)
 }
 
 static inline void nmdsa_config_print(void) { }
+static inline void nmdsa_fini(void) { }
 
 #endif
 

--- a/libnetmap/libnetmap.h
+++ b/libnetmap/libnetmap.h
@@ -733,4 +733,22 @@ void nmctx_lock(struct nmctx *);
 /* nmctx_unlock - unlock the list of nmem_d */
 void nmctx_unlock(struct nmctx *);
 
+#ifdef CONFIG_NETMAP_DSA
+
+int nmdsa_init(void);
+void nmdsa_config_print(void);
+
+#else
+
+static inline int nmdsa_init(void)
+{
+	struct nmctx *ctx = nmctx_get();
+	nmctx_ferror(ctx, "Error DSA support is disabled");
+	return -1;
+}
+
+static inline void nmdsa_config_print(void) { }
+
+#endif
+
 #endif /* LIBNETMAP_H_ */

--- a/libnetmap/nmdsa.c
+++ b/libnetmap/nmdsa.c
@@ -1,0 +1,372 @@
+/*
+ * Copyright (C) 2020 Semihalf
+ * Author: Lukasz Bartosik <lukasz.bartosik@semihalf.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifdef CONFIG_NETMAP_DSA
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+#include "libnetmap.h"
+
+#define MAX_TOKENS 7
+#define MAX_NAME_LEN 32
+#define MAX_LINE_LEN 80
+#define DSA_MAX_PROFILES 32
+#define TAG_TYPE_STR "tag-type"
+#define TAG_DSA_TYPE_STR "dsa"
+#define BIND_MODE_ALL "all"
+#define BIND_MODE_HOST "host"
+#define BIND_MODE_HW "hw"
+#define BIND_MODE_ANNOT_ALL "*"
+#define BIND_MODE_ANNOT_HOST "^"
+#define BIND_MODE_ANNOT_HW ""
+#define TAG_EDSA_TYPE_STR "edsa"
+#define DSA_CFG_FILE_NAME "dsa.cfg"
+
+typedef struct dsa_port_cfg {
+	char profile_name[MAX_NAME_LEN];
+	char name[NETMAP_REQ_IFNAMSIZ];
+	char cpu_port_name[NETMAP_REQ_IFNAMSIZ];
+	uint8_t bind_mode;
+	uint8_t port_num;
+	uint16_t vlan_id;
+	uint8_t vlan_pri;
+	uint8_t is_tagged;
+} dsa_port_cfg_t;
+
+typedef struct dsa_cfg {
+	dsa_port_cfg_t dsa_ports[DSA_MAX_PROFILES];
+	struct nmport_d *nm_cpu_port;
+	uint8_t nb_ports;
+	uint8_t tag_type;
+} dsa_cfg_t;
+
+static dsa_cfg_t dsa_cfg;
+
+static char *
+trim(char *str)
+{
+	int i, len;
+	char *ptr;
+
+	if (!str)
+		return NULL;
+
+	len = strlen(str);
+	if (!len)
+		return str;
+
+	ptr = str + len - 1;
+	for (i = 0; i < len; i++, ptr--)
+		if (!isspace(*ptr))
+			break;
+	*(ptr + 1) = '\0';
+
+	len = strlen(str);
+	for (i = 0; i < len; i++, str++)
+		if (!isspace(*str))
+			break;
+	return str;
+}
+
+static char *
+to_lower(char *str)
+{
+	int i;
+
+	for (i = 0; str[i]; i++)
+		str[i] = tolower(str[i]);
+
+	return str;
+}
+
+static char *
+bind_mode_to_str(uint8_t bind_mode)
+{
+	switch (bind_mode) {
+	case NR_REG_NIC_SW:
+		return BIND_MODE_ALL;
+	case NR_REG_ALL_NIC:
+		return BIND_MODE_HW;
+	case NR_REG_SW:
+		return BIND_MODE_HOST;
+	default:
+		return "n/a";
+	}
+}
+
+static int
+dsa_config_read(char *cfg_file_name)
+{
+	struct nmctx *ctx = nmctx_get();
+	int val, nb_tokens, nb_ports;
+	char line_buf[MAX_LINE_LEN];
+	char *token, *line = NULL;
+	char *tokens[MAX_TOKENS];
+	dsa_port_cfg_t *ports;
+	size_t size = 0;
+	FILE *cfg_file;
+
+	if (!cfg_file_name)
+		return -EINVAL;
+
+	cfg_file = fopen(cfg_file_name, "r");
+	if (!cfg_file) {
+		nmctx_ferror(ctx, "File \"%s\" does not exist\n",
+		             cfg_file_name);
+		return -EINVAL;
+	}
+
+	ports = dsa_cfg.dsa_ports;
+	nb_ports = dsa_cfg.nb_ports;
+	dsa_cfg.tag_type = TAG_DSA_TYPE;
+
+next_line:
+	while (getline(&line, &size, cfg_file) != -1) {
+		strncpy(line_buf, line, MAX_LINE_LEN);
+		line_buf[MAX_LINE_LEN - 1] = '\0';
+
+		nb_tokens = 0;
+		token = trim(strtok(line, " \t\n"));
+		if (!token || !strlen(token))
+			continue;
+
+		do {
+			if (*token == '#' || *token == '\0')
+				goto next_line;
+			if (nb_tokens >= MAX_TOKENS)
+				goto invalid_line;
+
+			tokens[nb_tokens++] = token;
+			token = trim(strtok(NULL, " \t\n"));
+		} while (token);
+
+		if (nb_ports >= DSA_MAX_PROFILES) {
+			nmctx_ferror(ctx,
+			             "Error number of profiles exceeds "
+			             "max supported %d",
+			             DSA_MAX_PROFILES);
+			goto error;
+		}
+
+		switch (nb_tokens) {
+		case 7:
+			/* get vlan identifier */
+			val = strtol(tokens[5], NULL, 10);
+			if (val < 0 || val > MAX_VLAN_ID) {
+				nmctx_ferror(ctx,
+				             "Vlan identifier '%d' is out of "
+				             "range [0, %d)",
+				             val, MAX_VLAN_ID);
+				goto error;
+			}
+			ports[nb_ports].vlan_id = val;
+
+			/* get vlan priority */
+			val = strtol(tokens[6], NULL, 10);
+			if (val < 0 || val > MAX_VLAN_PRIO) {
+				nmctx_ferror(ctx,
+				             "Vlan priority '%d' is out of "
+				             "range [0, %d)",
+				             val, MAX_VLAN_PRIO);
+				goto error;
+			}
+			ports[nb_ports].vlan_pri = val;
+			ports[nb_ports].is_tagged = 1;
+			/* intentional fallthrough */
+
+		case 5:
+			/* get profile name */
+			strncpy(ports[nb_ports].profile_name, tokens[0],
+			        MAX_NAME_LEN);
+			ports[nb_ports].profile_name[MAX_NAME_LEN - 1] = '\0';
+
+			/* get slave port name */
+			strncpy(ports[nb_ports].name, tokens[1],
+			        NETMAP_REQ_IFNAMSIZ);
+			ports[nb_ports].name[NETMAP_REQ_IFNAMSIZ - 1] = '\0';
+
+			/* get slave port number */
+			val = strtol(tokens[2], NULL, 10);
+			if (val < 0 || val > DSA_MAX_PORTS) {
+				nmctx_ferror(ctx,
+				             "Port number '%d' is out of range "
+				             "[0, %d)",
+				             val, DSA_MAX_PORTS);
+				goto error;
+			}
+			ports[nb_ports].port_num = val;
+
+			/* get bind mode */
+			tokens[3] = to_lower(tokens[3]);
+			if (!strcmp(tokens[3], BIND_MODE_ALL))
+				ports[nb_ports].bind_mode = NR_REG_NIC_SW;
+			else if (!strcmp(tokens[3], BIND_MODE_HW))
+				ports[nb_ports].bind_mode = NR_REG_ALL_NIC;
+			else if (!strcmp(tokens[3], BIND_MODE_HOST))
+				ports[nb_ports].bind_mode = NR_REG_SW;
+			else {
+				nmctx_ferror(ctx,
+				             "Invalid bind mode '%s'. "
+				             "Supported bind modes are: hw, "
+				             "host, all.",
+				             tokens[3]);
+				goto error;
+			}
+
+			/* get cpu port name */
+			strncpy(ports[nb_ports].cpu_port_name, tokens[4], NETMAP_REQ_IFNAMSIZ);
+			ports[nb_ports].cpu_port_name[NETMAP_REQ_IFNAMSIZ - 1] = '\0';
+
+			nb_ports++;
+			break;
+
+		case 2:
+			if (strcmp(tokens[0], TAG_TYPE_STR))
+				goto invalid_line;
+
+			/* get tag type */
+			if (!strcmp(tokens[1], TAG_DSA_TYPE_STR))
+				dsa_cfg.tag_type = TAG_DSA_TYPE;
+			else if (!strcmp(tokens[1], TAG_EDSA_TYPE_STR))
+				dsa_cfg.tag_type = TAG_EDSA_TYPE;
+			else {
+				nmctx_ferror(ctx, "Unsupported tag-type '%s'\n",
+				             tokens[1]);
+				goto error;
+			}
+			break;
+
+		default:
+			goto invalid_line;
+		}
+	}
+
+	dsa_cfg.nb_ports = nb_ports;
+	free(line);
+	return 0;
+
+invalid_line:
+	nmctx_ferror(ctx, "Invalid line \"%s\" in config file \"%s\"\n",
+	             line_buf, cfg_file_name);
+error:
+	free(line);
+	return -EINVAL;
+}
+
+static int
+dsa_config_validate(void)
+{
+	struct nmctx *ctx = nmctx_get();
+	dsa_port_cfg_t *ports;
+	int i, j;
+
+	if (!dsa_cfg.nb_ports) {
+		nmctx_ferror(ctx, "Error no ports configured\n");
+		return -EINVAL;
+	}
+
+	ports = dsa_cfg.dsa_ports;
+	for (i = 0; i < dsa_cfg.nb_ports; i++) {
+		for (j = 0; j < dsa_cfg.nb_ports; j++) {
+
+			if (i == j)
+				continue;
+
+			if (!strcmp(ports[i].profile_name, ports[j].profile_name)) {
+				nmctx_ferror(ctx, "Error duplicate profile name '%s'\n",
+					     ports[i].profile_name);
+				return -EINVAL;
+			}
+
+			if (strcmp(ports[i].cpu_port_name, ports[j].cpu_port_name)) {
+				nmctx_ferror(ctx, "Error only single cpu port is supported\n");
+				return -EINVAL;
+			}
+		}
+	}
+
+	return 0;
+}
+
+void
+nmdsa_config_print(void)
+{
+	dsa_port_cfg_t *ports;
+	int i;
+
+	ports = dsa_cfg.dsa_ports;
+	printf("======== DSA ports configuration ========\n");
+	printf("Tag type: %s\n\n", dsa_cfg.tag_type == TAG_DSA_TYPE
+	                                   ? TAG_DSA_TYPE_STR
+	                                   : TAG_EDSA_TYPE_STR);
+
+	printf("Profile name \tPort name \tPort number \tBind mode "
+	       "\tCpu port name \tVlan id \tVlan pri\n");
+	for (i = 0; i < dsa_cfg.nb_ports; i++) {
+
+		if (ports[i].is_tagged)
+			printf("%-16s %-8s \t%-4d \t\t%-7s \t%-4s \t\t%-4d "
+			       "\t\t%-4d\n",
+			       ports[i].profile_name, ports[i].name,
+			       ports[i].port_num,
+			       bind_mode_to_str(ports[i].bind_mode),
+			       ports[i].cpu_port_name, ports[i].vlan_id,
+			       ports[i].vlan_pri);
+		else
+			printf("%-16s %-8s \t%-4d \t\t%-7s \t%-4s \t\t%-4s "
+			       "\t\t%-4s\n",
+			       ports[i].profile_name, ports[i].name,
+			       ports[i].port_num,
+			       bind_mode_to_str(ports[i].bind_mode),
+			       ports[i].cpu_port_name, "--", "--");
+	}
+	printf("=========================================\n");
+}
+
+int
+nmdsa_init(void)
+{
+	int ret;
+
+	/* read DSA configuration from a file */
+	ret = dsa_config_read(DSA_CFG_FILE_NAME);
+	if (ret)
+		return ret;
+
+	/* validate DSA configuration */
+	ret = dsa_config_validate();
+	if (ret) {
+		nmdsa_config_print();
+		return ret;
+	}
+
+	return 0;
+}
+
+#endif /* CONFIG_NETMAP_DSA */

--- a/libnetmap/nmport.c
+++ b/libnetmap/nmport.c
@@ -535,13 +535,30 @@ int
 nmport_parse(struct nmport_d *d, const char *ifname)
 {
 	const char *scan = ifname;
+	uint16_t subsys_type;
 
-	if (nmreq_header_decode(&scan, &d->hdr, d->ctx) < 0) {
+	if (nmreq_header_decode(&scan, &subsys_type, &d->hdr, d->ctx) < 0) {
 		goto err;
 	}
 
 	/* parse the register request */
-	if (nmreq_register_decode(&scan, &d->reg, d->ctx) < 0) {
+	switch (subsys_type) {
+	case NETMAP_SUB_TYPE:
+	case VALE_SUB_TYPE:
+		if (nmreq_register_decode(&scan, &d->reg, d->ctx) < 0) {
+			goto err;
+		}
+		break;
+
+#ifdef CONFIG_NETMAP_DSA
+	case DSA_SUB_TYPE:
+		if (nmreq_register_decode_dsa(&scan, &d->reg, d->ctx) < 0) {
+			goto err;
+		}
+		break;
+#endif
+
+	default:
 		goto err;
 	}
 

--- a/libnetmap/nmport.c
+++ b/libnetmap/nmport.c
@@ -591,6 +591,16 @@ nmport_prepare(const char *ifname)
 	if (d == NULL)
 		goto err;
 
+#if CONFIG_NETMAP_DSA
+	char dsa_ifname[NETMAP_REQ_IFNAMSIZ];
+	if (!strncmp(ifname, DSA_IF_PREFIX, strlen(DSA_IF_PREFIX))) {
+		if (!nmdsa_find_port_cfg(d, ifname, dsa_ifname,
+					 NETMAP_REQ_IFNAMSIZ))
+			return NULL;
+		ifname = dsa_ifname;
+	}
+#endif
+
 	/* parse the header */
 	if (nmport_parse(d, ifname) < 0)
 		goto err;

--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -1579,6 +1579,11 @@ netmap_get_na(struct nmreq_header *hdr,
 	if (error || *na != NULL)
 		goto out;
 
+	/* try to see if this is a dsa port */
+	error = netmap_get_dsa_na(hdr, na, nmd, create);
+	if (error || *na != NULL)
+		goto out;
+
 	/* try to see if this is a bridge port */
 	error = netmap_get_vale_na(hdr, na, nmd, create);
 	if (error)
@@ -1882,7 +1887,8 @@ netmap_interp_ringid(struct netmap_priv_d *priv, struct nmreq_header *hdr)
 			}
 			priv->np_qfirst[t] = (nr_mode == NR_REG_SW ?
 				nma_get_nrings(na, t) : 0);
-			priv->np_qlast[t] = netmap_all_rings(na, t);
+			priv->np_qlast[t] = netmap_all_rings(na, t) -
+					nma_get_sync_nrings(na, t);
 			nm_prdis("%s: %s %d %d", nr_mode == NR_REG_SW ? "SW" : "NIC+SW",
 				nm_txrx2str(t),
 				priv->np_qfirst[t], priv->np_qlast[t]);

--- a/sys/dev/netmap/netmap_dsa.c
+++ b/sys/dev/netmap/netmap_dsa.c
@@ -903,6 +903,7 @@ netmap_get_dsa_na(struct nmreq_header *hdr, struct netmap_adapter **na,
 	dsa_na->up.nm_rxsync = netmap_dsa_sync;
 	dsa_na->up.nm_register = netmap_dsa_reg;
 	dsa_na->up.nm_poll = netmap_dsa_poll;
+	dsa_na->up.nm_ioctl_rxtx_sync = netmap_ioctl_dsa_rxtx_sync;
 	dsa_na->up.nm_krings_create = netmap_dsa_krings_create;
 	dsa_na->up.nm_krings_delete = netmap_dsa_krings_delete;
 

--- a/sys/dev/netmap/netmap_dsa.c
+++ b/sys/dev/netmap/netmap_dsa.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2020 Semihalf
+ * Author: Lukasz Bartosik <lukasz.bartosik@semihalf.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#if defined(linux)
+
+#include "bsd_glue.h"
+
+#else
+
+#error Unsupported platform
+
+#endif /* unsupported */
+
+/*
+ * common headers
+ */
+#include <net/netmap.h>
+#include <dev/netmap/netmap_kern.h>
+
+#ifdef WITH_DSA
+
+#include <dev/netmap/netmap_dsa.h>
+
+#endif /* WITH_DSA */

--- a/sys/dev/netmap/netmap_dsa.c
+++ b/sys/dev/netmap/netmap_dsa.c
@@ -44,4 +44,424 @@
 
 #include <dev/netmap/netmap_dsa.h>
 
+static struct netmap_dsa_adapter *dsa_na_tbl[DSA_MAX_PORTS];
+
+static int
+netmap_dsa_sync(struct netmap_kring *kring, int flags)
+{
+	nm_prerr("Error operation not supported");
+	return ENOTSUPP;
+}
+
+static int
+netmap_dsa_reg_port_net(struct netmap_adapter *cpu_na,
+                        struct netmap_dsa_adapter *dsa_na)
+{
+	struct netmap_dsa_slave_port_net *slave;
+
+	if (!cpu_na->dsa_cpu)
+		return EINVAL;
+
+	slave = &cpu_na->dsa_cpu->slaves_net[dsa_na->port_num];
+	if (slave->is_registered)
+		return EBUSY;
+
+	netmap_set_all_rings(cpu_na, NM_KR_LOCKED);
+	slave->is_registered = true;
+	cpu_na->dsa_cpu->reg_num_net++;
+	netmap_set_all_rings(cpu_na, 0);
+
+	if (netmap_debug & NM_DEBUG_DSA)
+		nm_prerr("DSA slave port net '%s' registered to '%s', "
+		         "port num = %d, tag type = %d, num of registered "
+		         "ports = %d",
+		         dsa_na->up.name, cpu_na->name, dsa_na->port_num,
+		         dsa_na->tag_type, cpu_na->dsa_cpu->reg_num_net);
+	return 0;
+}
+
+static int
+netmap_dsa_unreg_port_net(struct netmap_adapter *cpu_na,
+                          struct netmap_dsa_adapter *dsa_na)
+{
+	struct netmap_dsa_slave_port_net *slave;
+
+	if (!cpu_na->dsa_cpu)
+		return EINVAL;
+
+	slave = &cpu_na->dsa_cpu->slaves_net[dsa_na->port_num];
+	if (!slave->is_registered)
+		return EINVAL;
+
+	netmap_set_all_rings(cpu_na, NM_KR_LOCKED);
+	slave->is_registered = false;
+	cpu_na->dsa_cpu->reg_num_net--;
+	netmap_set_all_rings(cpu_na, 0);
+
+	if (netmap_debug & NM_DEBUG_DSA) {
+		nm_prerr("DSA slave port net '%s' deregistered from '%s, "
+		         "num of registered ports = %d",
+		         dsa_na->up.name, cpu_na->name,
+		         cpu_na->dsa_cpu->reg_num_net);
+	}
+
+	return 0;
+}
+
+static int
+netmap_dsa_reg_port_host(struct netmap_adapter *cpu_na,
+                         struct netmap_dsa_adapter *dsa_na,
+                         struct netmap_kring *host_kring)
+{
+	struct netmap_dsa_slave_port_host *slave;
+
+	if (!cpu_na->dsa_cpu)
+		return EINVAL;
+
+	slave = &cpu_na->dsa_cpu->slaves_host[dsa_na->port_num];
+	if (slave->is_registered)
+		return EBUSY;
+
+	mbq_lock(&host_kring->rx_queue);
+	slave->is_registered = true;
+	cpu_na->dsa_cpu->reg_num_host++;
+	mbq_unlock(&host_kring->rx_queue);
+
+	if (netmap_debug & NM_DEBUG_DSA)
+		nm_prerr("DSA slave port host '%s' registered to '%s', "
+		         "port num = %d, tag type = %d, num of registered "
+		         "ports = %d",
+		         dsa_na->up.name, cpu_na->name, dsa_na->port_num,
+		         dsa_na->tag_type, cpu_na->dsa_cpu->reg_num_host);
+	return 0;
+}
+
+static int
+netmap_dsa_unreg_port_host(struct netmap_adapter *cpu_na,
+                           struct netmap_dsa_adapter *dsa_na,
+                           struct netmap_kring *host_kring)
+{
+	struct netmap_dsa_slave_port_host *slave;
+
+	if (!cpu_na->dsa_cpu)
+		return EINVAL;
+
+	slave = &cpu_na->dsa_cpu->slaves_host[dsa_na->port_num];
+	if (!slave->is_registered)
+		return EINVAL;
+
+	mbq_lock(&host_kring->rx_queue);
+	slave->is_registered = false;
+	cpu_na->dsa_cpu->reg_num_host--;
+	mbq_unlock(&host_kring->rx_queue);
+
+	if (netmap_debug & NM_DEBUG_DSA) {
+		nm_prerr("DSA slave port host '%s' deregistered from '%s, "
+		         "num of registered ports = %d",
+		         dsa_na->up.name, cpu_na->name,
+		         cpu_na->dsa_cpu->reg_num_host);
+	}
+
+	return 0;
+}
+
+static int
+handle_bind_mode(struct netmap_dsa_adapter *dsa_na, u8 *net, u8 *host)
+{
+	*net = 0;
+	*host = 0;
+	switch (dsa_na->bind_mode) {
+	case NR_REG_ALL_NIC:
+		*net = 1;
+		break;
+
+	case NR_REG_SW:
+		*host = 1;
+		break;
+
+	case NR_REG_NIC_SW:
+		*net = 1;
+		*host = 1;
+		break;
+
+	default:
+		nm_prerr("Invalid bind mode %d", dsa_na->bind_mode);
+		return EINVAL;
+	}
+
+	return 0;
+}
+
+static int
+netmap_dsa_reg_port(struct netmap_adapter *cpu_na,
+                    struct netmap_dsa_adapter *dsa_na,
+                    struct netmap_kring *host_kring)
+{
+	u8 net, host;
+	int ret;
+
+	ret = handle_bind_mode(dsa_na, &net, &host);
+	if (ret)
+		return ret;
+
+	if (net) {
+		ret = netmap_dsa_reg_port_net(cpu_na, dsa_na);
+		if (ret)
+			return ret;
+	}
+
+	if (host) {
+		ret = netmap_dsa_reg_port_host(cpu_na, dsa_na, host_kring);
+		if (ret)
+			goto error;
+	}
+
+	return 0;
+error:
+	netmap_dsa_unreg_port_net(cpu_na, dsa_na);
+	return ret;
+}
+
+static int
+netmap_dsa_unreg_port(struct netmap_adapter *cpu_na,
+                      struct netmap_dsa_adapter *dsa_na,
+                      struct netmap_kring *host_kring)
+{
+	u8 net, host;
+	int ret;
+
+	ret = handle_bind_mode(dsa_na, &net, &host);
+	if (ret)
+		return ret;
+
+	if (net) {
+		ret = netmap_dsa_unreg_port_net(cpu_na, dsa_na);
+		if (ret)
+			return ret;
+	}
+
+	if (host) {
+		ret = netmap_dsa_unreg_port_host(cpu_na, dsa_na, host_kring);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+static int
+netmap_dsa_reg(struct netmap_adapter *na, int onoff)
+{
+	struct netmap_dsa_adapter *dsa_na = (struct netmap_dsa_adapter *)na;
+	struct netmap_adapter *cpu_na = dsa_na->cpu_na;
+	struct netmap_dsa_cpu_port *dsa_cpu;
+	struct netmap_kring *host_kring;
+	int ret;
+
+	if (na->active_fds)
+		return 0;
+
+	if (netmap_debug & NM_DEBUG_DSA)
+		nm_prerr("onoff = %d", onoff);
+
+	/* We lock on rx_queue from cpu port's host_kring to synchronize
+	 * netmap_transmit */
+	host_kring = NMR(cpu_na, NR_RX)[nma_get_nrings(na, NR_RX) + 1];
+	dsa_cpu = cpu_na->dsa_cpu;
+	if (onoff) {
+		if (!dsa_cpu) {
+			/*
+			 * Allocate memory on first DSA slave port
+			 * registration
+			 */
+			dsa_cpu = nm_os_malloc(sizeof(*cpu_na->dsa_cpu));
+			if (!dsa_cpu)
+				return ENOMEM;
+			/*
+			 * Lock setting of cpu_na->dsa_cpu pointer because it
+			 * is used to indicate whether DSA mode is enabled
+			 * in netmap_transmit
+			 */
+			mbq_lock(&host_kring->rx_queue);
+			cpu_na->dsa_cpu = dsa_cpu;
+			mbq_unlock(&host_kring->rx_queue);
+		}
+
+		ret = netmap_dsa_reg_port(cpu_na, dsa_na, host_kring);
+		if (ret)
+			return ret;
+
+		dsa_na_tbl[dsa_na->port_num] = dsa_na;
+		na->na_flags |= NAF_NETMAP_ON;
+		if (netmap_debug & NM_DEBUG_DSA)
+			nm_prerr("Enabled netmap mode for DSA "
+			         "interface '%s'",
+			         na->name);
+	} else {
+		ret = netmap_dsa_unreg_port(cpu_na, dsa_na, host_kring);
+		if (ret)
+			return ret;
+
+		if (!dsa_cpu->reg_num_net && !dsa_cpu->reg_num_host) {
+
+			/*
+			 * Lock setting of cpu_na->dsa_cpu pointer because it
+			 * is used to indicate whether DSA mode is enabled
+			 * in netmap_transmit
+			 */
+			mbq_lock(&host_kring->rx_queue);
+			cpu_na->dsa_cpu = NULL;
+			mbq_unlock(&host_kring->rx_queue);
+
+			nm_os_free(cpu_na->dsa_cpu);
+		}
+
+		dsa_na_tbl[dsa_na->port_num] = NULL;
+		na->na_flags &= ~NAF_NETMAP_ON;
+		if (netmap_debug & NM_DEBUG_DSA)
+			nm_prerr("Disabled netmap mode for DSA "
+			         "interface '%s'",
+			         na->name);
+	}
+
+	return 0;
+}
+
+static int
+netmap_dsa_krings_create(struct netmap_adapter *na)
+{
+	struct netmap_dsa_adapter *dsa_na = (struct netmap_dsa_adapter *)na;
+	int ret;
+
+	if (netmap_debug & NM_DEBUG_DSA)
+		nm_prerr("Creating krings");
+
+	ret = netmap_krings_create(na, 0);
+	if (ret)
+		return ret;
+
+	if (dsa_na->bind_mode == NR_REG_ALL_NIC ||
+	    dsa_na->bind_mode == NR_REG_NIC_SW)
+		na->rx_rings[DSA_RX_SYNC_RING]->nr_kflags |= NKR_NEEDRING;
+
+	return 0;
+}
+
+static void
+netmap_dsa_krings_delete(struct netmap_adapter *na)
+{
+	if (netmap_debug & NM_DEBUG_DSA)
+		nm_prerr("Deleting krings");
+
+	netmap_krings_delete(na);
+}
+
+int
+netmap_get_dsa_na(struct nmreq_header *hdr, struct netmap_adapter **na,
+                  struct netmap_mem_d *nmd, int create)
+{
+	struct nmreq_register *req =
+	        (struct nmreq_register *)(uintptr_t)hdr->nr_body;
+	struct netmap_dsa_adapter *dsa_na;
+	struct netmap_adapter *cpu_na;
+	struct ifnet *ifp;
+	int ret;
+
+	if (strncmp(hdr->nr_name, DSA_IF_PREFIX, strlen(DSA_IF_PREFIX)))
+		return 0;
+
+	/* Find DSA cpu port */
+	ifp = ifunit_ref(req->cpu_port_name);
+	if (!ifp)
+		return ENXIO;
+
+	if (!NM_NA_VALID(ifp)) {
+		nm_prerr("DSA cpu port '%s' is not native netmap interface",
+		         req->cpu_port_name);
+		return ENXIO;
+	}
+
+	cpu_na = NA(ifp);
+	if (cpu_na == NULL)
+		return ENXIO;
+
+	/* Find DSA lan port */
+	ifp = ifunit_ref(hdr->nr_name + strlen(DSA_IF_PREFIX));
+	if (!ifp) {
+		nm_prerr("DSA slave port '%s' not found",
+		         hdr->nr_name + strlen(DSA_IF_PREFIX));
+		return ENXIO;
+	}
+
+	if (dsa_na_tbl[req->port_num] &&
+	    dsa_na_tbl[req->port_num]->bind_mode == req->nr_mode) {
+		*na = &dsa_na_tbl[req->port_num]->up;
+		netmap_adapter_get(*na);
+		nm_prinf("Reusing DSA interface '%s'", (*na)->name);
+		return 0;
+	}
+
+	dsa_na = nm_os_malloc(sizeof(*dsa_na));
+	if (dsa_na == NULL)
+		return ENOMEM;
+
+	snprintf(dsa_na->up.name, sizeof(dsa_na->up.name), "%s", hdr->nr_name);
+	dsa_na->up.nm_txsync = netmap_dsa_sync;
+	dsa_na->up.nm_rxsync = netmap_dsa_sync;
+	dsa_na->up.nm_register = netmap_dsa_reg;
+	dsa_na->up.nm_krings_create = netmap_dsa_krings_create;
+	dsa_na->up.nm_krings_delete = netmap_dsa_krings_delete;
+
+	dsa_na->up.num_tx_rings = DSA_TX_RINGS_NUM;
+	dsa_na->up.num_rx_rings = DSA_RX_RINGS_NUM;
+	dsa_na->up.num_rx_sync_rings = DSA_RX_SYNC_RINGS_NUM;
+	dsa_na->up.num_tx_desc = cpu_na->num_tx_desc;
+	dsa_na->up.num_rx_desc = cpu_na->num_rx_desc;
+
+	dsa_na->up.ifp = ifp;
+	dsa_na->up.na_flags = NAF_HOST_RINGS;
+	dsa_na->port_num = req->port_num;
+	dsa_na->tag_type = req->tag_type;
+	dsa_na->bind_mode = req->nr_mode;
+	dsa_na->cpu_na = cpu_na;
+
+	/* Validate tag */
+	switch (dsa_na->tag_type) {
+	case TAG_DSA_TYPE:
+	case TAG_EDSA_TYPE:
+		break;
+	default:
+		nm_prerr("Unsupported tag type %d", dsa_na->tag_type);
+		ret = EINVAL;
+		goto free_dsa_na;
+	};
+
+	if (netmap_debug & NM_DEBUG_DSA) {
+		nm_prerr("DSA cpu port '%s' rx/tx rings = %d/%d,"
+		         " rx/tx descs = %d/%d",
+		         req->cpu_port_name, cpu_na->num_rx_rings,
+		         cpu_na->num_tx_rings, cpu_na->num_rx_desc,
+		         cpu_na->num_tx_desc);
+
+		nm_prerr("DSA slave port '%s' rx/tx rings = %d/%d,"
+		         " rx/tx descs = %d/%d",
+		         dsa_na->up.name, dsa_na->up.num_rx_rings,
+		         dsa_na->up.num_tx_rings, dsa_na->up.num_rx_desc,
+		         dsa_na->up.num_tx_desc);
+	}
+
+	ret = netmap_attach_common(&dsa_na->up);
+	if (ret)
+		goto free_dsa_na;
+	*na = &dsa_na->up;
+	netmap_adapter_get(*na);
+
+	nm_prinf("Created DSA interface '%s'", dsa_na->up.name);
+	return 0;
+
+free_dsa_na:
+	nm_os_free(dsa_na);
+	return ret;
+}
+
 #endif /* WITH_DSA */

--- a/sys/dev/netmap/netmap_dsa.c
+++ b/sys/dev/netmap/netmap_dsa.c
@@ -81,6 +81,9 @@ netmap_dsa_print_port_stats_net(struct netmap_adapter *dsa_na,
 	nm_prerr("drop_rx_sync_full : %llu", slave->stats.drop_rx_sync_full);
 	nm_prerr("event_rx_full : %llu", slave->stats.event_rx_no_space);
 	nm_prerr("rcv_pkts : %llu", slave->stats.rcv_pkts);
+	nm_prerr("drop_tx_no_headroom : %llu",
+	         slave->stats.drop_tx_no_headroom);
+	nm_prerr("sent_pkts : %llu", slave->stats.sent_pkts);
 }
 
 static void
@@ -554,6 +557,8 @@ netmap_dsa_tx_sync(struct netmap_kring *kring, int flags)
 			nm_prerr("Error packet headroom %d is less than "
 			         "required for tag %d. Packet will be dropped",
 			         to_slot->data_offs, dsa_na->tag_len);
+
+			slave->stats.drop_tx_no_headroom++;
 		}
 
 		head = nm_ring_next(to_ring, head);
@@ -565,6 +570,8 @@ netmap_dsa_tx_sync(struct netmap_kring *kring, int flags)
 
 		from_kring->nr_hwtail = from_ring->tail;
 		from_kring->nr_hwcur = from_kring->rhead;
+
+		slave->stats.sent_pkts += n;
 	}
 
 	if (slave->tx_cpu_kring_lock)

--- a/sys/dev/netmap/netmap_dsa.h
+++ b/sys/dev/netmap/netmap_dsa.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2020 Semihalf
+ * Author: Lukasz Bartosik <lukasz.bartosik@semihalf.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _NET_NETMAP_DSA_H__
+#define _NET_NETMAP_DSA_H__
+
+#endif

--- a/sys/dev/netmap/netmap_dsa.h
+++ b/sys/dev/netmap/netmap_dsa.h
@@ -27,4 +27,12 @@
 #ifndef _NET_NETMAP_DSA_H__
 #define _NET_NETMAP_DSA_H__
 
+#define DSA_RX_RINGS_NUM 1
+#define DSA_TX_RINGS_NUM 1
+#define DSA_RX_SYNC_RINGS_NUM 1
+
+#define DSA_RX_RING 0
+#define DSA_RX_HOST_RING 1
+#define DSA_RX_SYNC_RING 2
+
 #endif

--- a/sys/dev/netmap/netmap_dsa.h
+++ b/sys/dev/netmap/netmap_dsa.h
@@ -35,4 +35,89 @@
 #define DSA_RX_HOST_RING 1
 #define DSA_RX_SYNC_RING 2
 
+#define DSA_FORWARD_MODE 3
+
+static inline union dsa_tag *
+netmap_dsa_get_tag(u8 *buf, u8 tag_type, u8 *tag_len)
+{
+	struct edsa_tag *etag;
+	union dsa_tag *dtag;
+
+	buf += 2 * ETH_ALEN;
+	if (tag_type == TAG_EDSA_TYPE) {
+		etag = (struct edsa_tag *)buf;
+		if (etag->dsa_ether_type != ETH_P_EDSA) {
+			if (netmap_debug & NM_DEBUG_DSA) {
+				nm_prerr("EDSA invalid header value %x, "
+				         "expected %x",
+				         etag->dsa_ether_type, ETH_P_EDSA);
+			}
+			return NULL;
+		}
+
+		dtag = &etag->dtag;
+		*tag_len = EDSA_TAG_LEN;
+	} else {
+		dtag = (union dsa_tag *)buf;
+		*tag_len = DSA_TAG_LEN;
+	}
+
+	dtag->u32 = ntohl(dtag->u32);
+	return dtag;
+}
+
+static inline void
+netmap_dsa_move_buffers(struct netmap_slot *to_slot,
+                        struct netmap_slot *from_slot)
+{
+	u32 pkt = to_slot->buf_idx;
+
+	to_slot->buf_idx = from_slot->buf_idx;
+	from_slot->buf_idx = pkt;
+
+	to_slot->len = from_slot->len;
+	to_slot->data_offs = from_slot->data_offs;
+
+	to_slot->flags |= NS_BUF_CHANGED;
+	from_slot->flags |= NS_BUF_CHANGED;
+}
+
+static inline void
+netmap_dsa_move_tag_buf(struct netmap_slot *slot, u8 *buf,
+                        union dsa_tag *tag_ptr, u8 tag_len)
+{
+	union dsa_tag tag = *tag_ptr;
+
+	memmove(buf + tag_len, buf, 2 * ETH_ALEN);
+	slot->data_offs += tag_len;
+	slot->len -= tag_len;
+
+	tag_ptr = (union dsa_tag *)(buf + tag_len - DSA_TAG_LEN);
+	*tag_ptr = tag;
+}
+
+static inline uint32_t
+nm_ring_next(struct netmap_ring *r, uint32_t i)
+{
+	return (unlikely(i + 1 == r->num_slots) ? 0 : i + 1);
+}
+
+static inline uint32_t
+nm_rxring_pkts_avail(struct netmap_ring *ring)
+{
+	int ret = ring->tail - ring->head;
+	if (ret < 0)
+		ret += ring->num_slots;
+	return ret;
+}
+
+static inline int
+nm_rxring_slots_avail(struct netmap_ring *ring)
+{
+	int ret = ring->head - ring->tail;
+	if (ret <= 0)
+		ret += ring->num_slots - 1;
+	return ret;
+}
+
 #endif

--- a/sys/dev/netmap/netmap_dsa.h
+++ b/sys/dev/netmap/netmap_dsa.h
@@ -35,6 +35,7 @@
 #define DSA_RX_HOST_RING 1
 #define DSA_RX_SYNC_RING 2
 
+#define DSA_FROM_CPU_MODE 1
 #define DSA_FORWARD_MODE 3
 
 static inline union dsa_tag *
@@ -93,6 +94,16 @@ netmap_dsa_move_tag_buf(struct netmap_slot *slot, u8 *buf,
 	slot->len -= tag_len;
 
 	tag_ptr = (union dsa_tag *)(buf + tag_len - DSA_TAG_LEN);
+	*tag_ptr = tag;
+}
+
+static inline void
+netmap_dsa_move_tag_skbuf(struct mbuf *m, union dsa_tag *tag_ptr, u8 tag_len)
+{
+	union dsa_tag tag = *tag_ptr;
+
+	memmove(m->data + tag_len, m->data, 2 * ETH_ALEN);
+	tag_ptr = (union dsa_tag *)(m->data + tag_len - DSA_TAG_LEN);
 	*tag_ptr = tag;
 }
 

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -703,9 +703,23 @@ struct nm_config_info {
 };
 
 #ifdef WITH_DSA
+struct netmap_dsa_stats {
+	u64 drop_rx_inv_tag; /* Dropped pkts because of invalid tag */
+	u64 drop_rx_inv_port; /* Dropped pkts because of invalid port */
+	u64 drop_rx_not_reg; /* Dropped pkts for not registered port */
+};
+
+struct netmap_dsa_slave_net_stats {
+	u64 drop_rx_full; /* Dropped pkts - no space in rx kring */
+	u64 drop_rx_sync_full; /* Dropped pkts - no space in rx sync kring */
+	u64 event_rx_no_space; /* Event - not enough space avail in rx kring */
+	u64 rcv_pkts; /* Number of received packets */
+};
+
 struct netmap_dsa_slave_port_net {
 	struct netmap_kring *rx_kring;
 	struct netmap_kring *rx_sync_kring;
+	struct netmap_dsa_slave_net_stats stats;
 	NM_SELINFO_T *rx_si;
 	bool is_rx_locked;		/* Is rx sync kring locked */
 	bool is_registered;		/* Is port registered */
@@ -733,6 +747,8 @@ struct netmap_dsa_cpu_port {
 	struct netmap_dsa_slave_port_net slaves_net[DSA_MAX_PORTS];
 	/* Registered DSA slave ports for host communication */
 	struct netmap_dsa_slave_port_host slaves_host[DSA_MAX_PORTS];
+ 	/*  Network port independent statistics*/
+ 	struct netmap_dsa_stats stats_net;
 	/* Number of registered slave ports for network communication*/
 	u8 reg_num_net;
 	/* Number of registered slave ports for host communication */
@@ -1765,6 +1781,7 @@ enum {                                  /* debug flags */
 	NM_DEBUG_VALE = 0x8000,		/* debug messages from memory allocators */
 	NM_DEBUG_BDG = NM_DEBUG_VALE,
 	NM_DEBUG_DSA = 0x010000,	/* DSA debug messages */
+	NM_DEBUG_DSA_STATS = 0x020000,	/* DSA print port statistics */
 };
 
 extern int netmap_txsync_retry;

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -1731,6 +1731,7 @@ extern struct nm_bridge *nm_bridges;
 /* Various prototypes */
 int netmap_poll(struct netmap_priv_d *, int events, NM_SELRECORD_T *td);
 int netmap_dsa_poll(struct netmap_priv_d *, int events, NM_SELRECORD_T *td);
+int netmap_ioctl_dsa_rxtx_sync(struct netmap_priv_d *priv, u_long cmd);
 int netmap_init(void);
 void netmap_fini(void);
 int netmap_get_memory(struct netmap_priv_d* p);

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -726,6 +726,8 @@ struct netmap_dsa_slave_port_net {
 };
 
 struct netmap_dsa_slave_port_host {
+	struct netmap_kring *host_kring;
+	char *port_name;
 	bool is_registered;		/* Is port registered */
 };
 
@@ -1260,6 +1262,7 @@ struct netmap_dsa_adapter {
 	uint16_t port_num;
 	uint16_t tag_type;
 	u8 bind_mode;
+	u8 tag_len;
 };
 
 #endif /* WITH_DSA */
@@ -1672,6 +1675,9 @@ int netmap_get_dsa_na(struct nmreq_header *hdr, struct netmap_adapter **na,
 int netmap_dsa_dispatch_rcv_pkts(struct netmap_kring *from_kring,
 				 struct netmap_adapter *cpu_na,
 				 uint16_t poll_port_num);
+int netmap_dsa_enqueue_host_pkt(struct netmap_adapter *cpu_na,
+				struct mbuf *m);
+int netmap_dsa_rxsync_from_host(struct netmap_kring *kring, int flags);
 #else /* !WITH_DSA */
 #define netmap_get_dsa_na(hdr, _2, _3, _4)	\
 	(!strncmp(hdr->nr_name, DSA_IF_PREFIX, strlen(DSA_IF_PREFIX)) ? EOPNOTSUPP : 0)

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -716,6 +716,11 @@ struct netmap_dsa_slave_net_stats {
 	u64 rcv_pkts; /* Number of received packets */
 };
 
+struct netmap_dsa_slave_host_stats {
+	u64 drop_rx_no_space; /* Dropped pkts not enough space in host kring */
+	u64 rcv_pkts; /* Number of packets submitted to host rx kring */
+};
+
 struct netmap_dsa_slave_port_net {
 	struct netmap_kring *rx_kring;
 	struct netmap_kring *rx_sync_kring;
@@ -727,6 +732,7 @@ struct netmap_dsa_slave_port_net {
 
 struct netmap_dsa_slave_port_host {
 	struct netmap_kring *host_kring;
+	struct netmap_dsa_slave_host_stats stats;
 	char *port_name;
 	bool is_registered;		/* Is port registered */
 };
@@ -751,6 +757,8 @@ struct netmap_dsa_cpu_port {
 	struct netmap_dsa_slave_port_host slaves_host[DSA_MAX_PORTS];
  	/*  Network port independent statistics*/
  	struct netmap_dsa_stats stats_net;
+	/* Host port independent statistics*/
+	 struct netmap_dsa_stats stats_host;
 	/* Number of registered slave ports for network communication*/
 	u8 reg_num_net;
 	/* Number of registered slave ports for host communication */

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -63,6 +63,9 @@
 #if defined(CONFIG_NETMAP_NULL)
 #define WITH_NMNULL
 #endif
+#if defined(CONFIG_NETMAP_DSA)
+#define WITH_DSA
+#endif
 
 #elif defined (_WIN32)
 #define WITH_VALE	// comment out to disable VALE support

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -714,6 +714,8 @@ struct netmap_dsa_slave_net_stats {
 	u64 drop_rx_sync_full; /* Dropped pkts - no space in rx sync kring */
 	u64 event_rx_no_space; /* Event - not enough space avail in rx kring */
 	u64 rcv_pkts; /* Number of received packets */
+	u64 drop_tx_no_headroom; /* Dropped pkts - not enough headroom in pkt */
+	u64 sent_pkts; /* Number of packets submitted to cpu tx kring */
 };
 
 struct netmap_dsa_slave_host_stats {

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -935,6 +935,7 @@ struct netmap_adapter {
 	int (*nm_notify)(struct netmap_kring *kring, int flags);
 	int (*nm_bufcfg)(struct netmap_kring *kring, uint64_t target);
 	int (*nm_poll)(struct netmap_priv_d *priv, int events, NM_SELRECORD_T *sr);
+	int (*nm_ioctl_rxtx_sync)(struct netmap_priv_d *priv, u_long cmd);
 
 #define NAF_FORCE_READ      1
 #define NAF_FORCE_RECLAIM   2

--- a/sys/net/netmap.h
+++ b/sys/net/netmap.h
@@ -999,4 +999,29 @@ struct nmreq_opt_offsets {
 	uint64_t		nro_min_gap;
 };
 
+#ifdef CONFIG_NETMAP_DSA
+
+union dsa_tag {
+	struct {
+		uint32_t vlan_id   : 12;
+		uint32_t resvd3    : 1;
+		uint32_t vlan_prio : 3;
+		uint32_t dei       : 1;
+		uint32_t resvd2    : 2;
+		uint32_t port      : 5;
+		uint32_t resvd1    : 5;
+		uint32_t tagged    : 1;
+		uint32_t mode      : 2;
+	} s;
+	uint32_t u32;
+};
+
+struct edsa_tag {
+	uint16_t dsa_ether_type;
+	uint16_t reserved;
+	union dsa_tag dtag;
+};
+
+#endif /* CONFIG_NETMAP_DSA */
+
 #endif /* _NET_NETMAP_H_ */

--- a/sys/net/netmap.h
+++ b/sys/net/netmap.h
@@ -157,6 +157,12 @@
  *   adapter.
  */
 
+enum {
+	NETMAP_SUB_TYPE	= 1,
+	VALE_SUB_TYPE,
+	DSA_SUB_TYPE,
+};
+
 /*
  * struct netmap_slot is a buffer descriptor
  */
@@ -607,6 +613,19 @@ struct nmreq_register {
 	uint32_t	nr_mode;	/* specify NR_REG_* modes */
 	uint32_t	nr_extra_bufs;	/* number of requested extra buffers */
 
+#ifdef CONFIG_NETMAP_DSA
+	char cpu_port_name[NETMAP_REQ_IFNAMSIZ];	/* cpu port name */
+#define DSA_MAX_PORTS	8
+	uint16_t	port_num;	/* port number in a switch */
+#define TAG_DSA_TYPE	1
+#define TAG_EDSA_TYPE	2
+	uint16_t	tag_type;	/* tag type: DSA or EDSA */
+#define MAX_VLAN_ID 4096
+	uint16_t	vlan_id;	/* vlan identifier */
+#define MAX_VLAN_PRIO 8
+	uint8_t		vlan_prio;	/* vlan priority */
+	uint8_t		tagged;		/* is port vlan tagged */
+#endif
 	uint64_t	nr_flags;	/* additional flags (see below) */
 /* monitors use nr_ringid and nr_mode to select the rings to monitor */
 #define NR_MONITOR_TX	0x100

--- a/utils/ctrl-api-test.c
+++ b/utils/ctrl-api-test.c
@@ -1831,7 +1831,7 @@ nmreq_hdr_parsing(struct TestContext *ctx,
 	orig_hdr = *hdr;
 
 	printf("nmreq_header: \"%s\"\n", ctx->ifparse);
-	if (nmreq_header_decode(&ctx->ifparse, hdr, ctx->nmctx) < 0) {
+	if (nmreq_header_decode(&ctx->ifparse, NULL, hdr, ctx->nmctx) < 0) {
 		if (t->exp_error > 0) {
 			if (errno != t->exp_error) {
 				printf("!!! got errno=%d, want %d\n",


### PR DESCRIPTION
This PR introduces DSA support to netmap. A series of patches enable build and operation of the switch ports with the v4.19.91 Linux kernel.