### PR TITLE
Edsa fixes

### DIFF
--- a/LINUX/final-patches/vanilla--mvneta.c--41300--41991
+++ b/LINUX/final-patches/vanilla--mvneta.c--41300--41991
@@ -1,8 +1,8 @@
 diff --git a/mvneta.c b/mvneta.c
-index 4313bbb2..89817344 100644
+index b4ed7d39..2bcf1502 100644
 --- a/mvneta.c
 +++ b/mvneta.c
-@@ -448,6 +448,10 @@ struct mvneta_port {
+@@ -449,6 +449,10 @@ struct mvneta_port {
  
  	u32 indir[MVNETA_RSS_LU_TABLE_SIZE];
  
@@ -13,7 +13,7 @@ index 4313bbb2..89817344 100644
  	/* Flags for special SoC configurations */
  	bool neta_armada3700;
  	u16 rx_offset_correction;
-@@ -617,6 +621,11 @@ struct mvneta_rx_queue {
+@@ -618,6 +622,11 @@ struct mvneta_rx_queue {
  	int first_to_refill;
  	u32 refill_num;
  
@@ -25,7 +25,7 @@ index 4313bbb2..89817344 100644
  	/* pointer to uncomplete skb buffer */
  	struct sk_buff *skb;
  	int left_size;
-@@ -644,6 +653,10 @@ static int global_port_id;
+@@ -645,6 +654,10 @@ static int global_port_id;
  #define MVNETA_DRIVER_NAME "mvneta"
  #define MVNETA_DRIVER_VERSION "1.0"
  
@@ -36,7 +36,7 @@ index 4313bbb2..89817344 100644
  /* Utility/helper methods */
  
  /* Write helper method */
-@@ -1883,6 +1896,10 @@ static void mvneta_rxq_drop_pkts(struct mvneta_port *pp,
+@@ -1884,6 +1897,10 @@ static void mvneta_rxq_drop_pkts(struct mvneta_port *pp,
  		return;
  	}
  
@@ -47,7 +47,7 @@ index 4313bbb2..89817344 100644
  	for (i = 0; i < rxq->size; i++) {
  		struct mvneta_rx_desc *rx_desc = rxq->descs + i;
  		void *data = rxq->buf_virt_addr[i];
-@@ -1931,6 +1948,14 @@ static int mvneta_rx_swbm(struct napi_struct *napi,
+@@ -1932,6 +1949,14 @@ static int mvneta_rx_swbm(struct napi_struct *napi,
  	u32 rcvd_pkts = 0;
  	u32 rcvd_bytes = 0;
  
@@ -62,15 +62,18 @@ index 4313bbb2..89817344 100644
  	/* Get number of received packets */
  	rx_todo = mvneta_rxq_busy_desc_num_get(pp, rxq);
  	rx_proc = 0;
-@@ -2759,6 +2784,7 @@ static int mvneta_poll(struct napi_struct *napi, int budget)
+@@ -2760,6 +2785,10 @@ static int mvneta_poll(struct napi_struct *napi, int budget)
  	int rx_queue;
  	struct mvneta_port *pp = netdev_priv(napi->dev);
  	struct mvneta_pcpu_port *port = this_cpu_ptr(pp->ports);
++#ifdef DEV_NETMAP
 +	int bit;
++	u32 tx_mask = MVNETA_TX_INTR_MASK(txq_number);
++#endif /* DEV_NETMAP */
  
  	if (!netif_running(pp->dev)) {
  		napi_complete(napi);
-@@ -2779,6 +2805,13 @@ static int mvneta_poll(struct napi_struct *napi, int budget)
+@@ -2780,6 +2809,14 @@ static int mvneta_poll(struct napi_struct *napi, int budget)
  
  	/* Release Tx descriptors */
  	if (cause_rx_tx & MVNETA_TX_INTR_MASK_ALL) {
@@ -80,11 +83,24 @@ index 4313bbb2..89817344 100644
 +				netmap_tx_irq(pp->dev, bit);
 +			}
 +		}
++		tx_mask = ~cause_rx_tx & MVNETA_TX_INTR_MASK_ALL;
 +#endif /* DEV_NETMAP */
  		mvneta_tx_done_gbe(pp, (cause_rx_tx & MVNETA_TX_INTR_MASK_ALL));
  		cause_rx_tx &= ~MVNETA_TX_INTR_MASK_ALL;
  	}
-@@ -2833,6 +2866,12 @@ static int mvneta_rxq_fill(struct mvneta_port *pp, struct mvneta_rx_queue *rxq,
+@@ -2812,7 +2849,11 @@ static int mvneta_poll(struct napi_struct *napi, int budget)
+ 			local_irq_save(flags);
+ 			mvreg_write(pp, MVNETA_INTR_NEW_MASK,
+ 				    MVNETA_RX_INTR_MASK(rxq_number) |
++#ifdef DEV_NETMAP
++				    tx_mask |
++#else
+ 				    MVNETA_TX_INTR_MASK(txq_number) |
++#endif /* DEV_NETMAP */
+ 				    MVNETA_MISCINTR_INTR_MASK);
+ 			local_irq_restore(flags);
+ 		} else {
+@@ -2834,6 +2875,12 @@ static int mvneta_rxq_fill(struct mvneta_port *pp, struct mvneta_rx_queue *rxq,
  {
  	int i;
  
@@ -97,7 +113,7 @@ index 4313bbb2..89817344 100644
  	for (i = 0; i < num; i++) {
  		memset(rxq->descs + i, 0, sizeof(struct mvneta_rx_desc));
  		if (mvneta_rx_refill(pp, rxq->descs + i, rxq,
-@@ -3143,7 +3182,10 @@ static int mvneta_setup_txqs(struct mvneta_port *pp)
+@@ -3142,7 +3189,10 @@ static int mvneta_setup_txqs(struct mvneta_port *pp)
  			return err;
  		}
  	}
@@ -109,7 +125,7 @@ index 4313bbb2..89817344 100644
  	return 0;
  }
  
-@@ -3235,6 +3277,13 @@ static int mvneta_change_mtu(struct net_device *dev, int mtu)
+@@ -3234,6 +3284,13 @@ static int mvneta_change_mtu(struct net_device *dev, int mtu)
  	struct mvneta_port *pp = netdev_priv(dev);
  	int ret;
  
@@ -123,7 +139,7 @@ index 4313bbb2..89817344 100644
  	if (!IS_ALIGNED(MVNETA_RX_PKT_SIZE(mtu), 8)) {
  		netdev_info(dev, "Illegal MTU value %d, rounding to %d\n",
  			    mtu, ALIGN(MVNETA_RX_PKT_SIZE(mtu), 8));
-@@ -4619,6 +4668,10 @@ static int mvneta_probe(struct platform_device *pdev)
+@@ -4619,6 +4676,10 @@ static int mvneta_probe(struct platform_device *pdev)
  
  	platform_set_drvdata(pdev, pp->dev);
  
@@ -134,7 +150,7 @@ index 4313bbb2..89817344 100644
  	return 0;
  
  err_netdev:
-@@ -4651,6 +4704,9 @@ static int mvneta_remove(struct platform_device *pdev)
+@@ -4653,6 +4714,9 @@ static int mvneta_remove(struct platform_device *pdev)
  	struct mvneta_port *pp = netdev_priv(dev);
  
  	unregister_netdev(dev);

--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -4205,7 +4205,7 @@ do_rcv:
 			 * We only allow one thread to handle received
 			 * packets on DSA cpu port
 			 */
-			return 0;
+			goto exit;
 		}
 
 		/* Iterate over DSA cpu port rings */

--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -4063,10 +4063,16 @@ netmap_dsa_poll(struct netmap_priv_d *priv, int events, NM_SELRECORD_T *sr) {
 	want_tx = events & (POLLOUT | POLLWRNORM);
 	want_rx = events & (POLLIN | POLLRDNORM);
 
-	nm_os_selrecord(sr, dsa_cpu->np_si[NR_RX]);
-	nm_os_selrecord(sr, dsa_cpu->np_si[NR_TX]);
-	nm_os_selrecord(sr, slave_host->rx_si);
-	nm_os_selrecord(sr, slave->rx_si);
+	if (dsa_na->bind_mode == NR_REG_ALL_NIC ||
+	    dsa_na->bind_mode == NR_REG_NIC_SW) {
+		nm_os_selrecord(sr, dsa_cpu->np_si[NR_RX]);
+		nm_os_selrecord(sr, &slave->tx_kring->si);
+		nm_os_selrecord(sr, slave->rx_si);
+	}
+
+	if (dsa_na->bind_mode == NR_REG_SW ||
+	    dsa_na->bind_mode == NR_REG_NIC_SW)
+		nm_os_selrecord(sr, slave_host->rx_si);
 
 	poll_cpu_port = dsa_na->bind_mode == NR_REG_SW ? 0 : 1;
 

--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -4037,6 +4037,8 @@ netmap_dsa_poll(struct netmap_priv_d *priv, int events, NM_SELRECORD_T *sr) {
 	int poll_port_num = dsa_na->port_num;
 	struct netmap_dsa_slave_port_net *slave =
 			&dsa_cpu->slaves_net[poll_port_num];
+	struct netmap_dsa_slave_port_host *slave_host =
+			&dsa_cpu->slaves_host[poll_port_num];
 	int sync_flags = dsa_cpu->np_sync_flags;
 	struct netmap_kring *kring;
 	struct netmap_ring *ring;
@@ -4063,6 +4065,7 @@ netmap_dsa_poll(struct netmap_priv_d *priv, int events, NM_SELRECORD_T *sr) {
 
 	nm_os_selrecord(sr, dsa_cpu->np_si[NR_RX]);
 	nm_os_selrecord(sr, dsa_cpu->np_si[NR_TX]);
+	nm_os_selrecord(sr, slave_host->rx_si);
 	nm_os_selrecord(sr, slave->rx_si);
 
 	poll_cpu_port = dsa_na->bind_mode == NR_REG_SW ? 0 : 1;

--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -1375,7 +1375,7 @@ netmap_rxsync_from_host_offset(struct netmap_kring *kring, int flags,
 			if (netmap_debug & NM_DEBUG_HOST)
 				nm_prinf("%s", nm_dump_buf(NMB(na, slot),len, 128, NULL));
 
-			slot->len = len;
+			slot->len = len - offset;
 			slot->flags = 0;
 			slot->data_offs = offset;
 			nm_i = nm_next(nm_i, lim);

--- a/sys/dev/netmap/netmap_dsa.c
+++ b/sys/dev/netmap/netmap_dsa.c
@@ -226,6 +226,7 @@ netmap_dsa_reg_port_host(struct netmap_adapter *cpu_na,
 
 	mbq_lock(&host_kring->rx_queue);
 	slave->host_kring = dsa_na->up.rx_rings[DSA_RX_HOST_RING];
+	slave->rx_si = &dsa_na->up.rx_rings[DSA_RX_HOST_RING]->si;
 	slave->port_name = dsa_na->up.name;
 	slave->is_registered = true;
 	cpu_na->dsa_cpu->reg_num_host++;
@@ -844,7 +845,7 @@ netmap_dsa_enqueue_host_pkt(struct netmap_adapter *cpu_na, struct mbuf *m)
 	mbq_unlock(q);
 
 	if (ret)
-		kring->nm_notify(kring, 0);
+		nm_os_selwakeup(&kring->si);
 exit:
 	return ret;
 }

--- a/sys/dev/netmap/netmap_kern.h
+++ b/sys/dev/netmap/netmap_kern.h
@@ -736,6 +736,7 @@ struct netmap_dsa_slave_port_net {
 };
 
 struct netmap_dsa_slave_port_host {
+	NM_SELINFO_T *rx_si;
 	struct netmap_kring *host_kring;
 	struct netmap_dsa_slave_host_stats stats;
 	char *port_name;


### PR DESCRIPTION
The patchset includes the following changes:

1. Fix for how transmit interrupts are acknowledged in mvneta driver. Previously transmit interrupts were incorrectly acked by a driver which caused high CPU usage even though no packets were transmitted.
2. Fix length of packets received from host stack. Previously offset to data was not removed from packet length causing it to be erroneous.
3. Fix notification when a host packet arrives. To notify that a host pkt has arrived use a separate wait queue instead of common wait queue. When common queue is used thread waiting for pkts from network can be awaken instead of thread waiting for pkts from host stack.
4. Fix how wait queues are used in netmap_dsa_poll:
- Instead of using generic wait queue for transmit use specific wait queue which is bound to transmit kring.
- Submit only to wait queues which are relevant in a current bind mode.
5. Fix return point when receive spinlock is busy.